### PR TITLE
Fix celeryd startup

### DIFF
--- a/config/bin/rtd-start.sh
+++ b/config/bin/rtd-start.sh
@@ -12,5 +12,7 @@ echo "from django.contrib.auth.models import User; User.objects.create_superuser
 $PYTHON manage.py loaddata test_data
 $PYTHON manage.py makemessages --all
 $PYTHON manage.py compilemessages
+
+export C_FORCE_ROOT="true"
 /venv/bin/python manage.py celeryd -l INFO &
 /venv/bin/python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Celery will throw exception if you'll try to start its daemon from the root. This env var will force it to start.