### PR TITLE
Pin to 14.04 to make Dockerfile work again.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:14.04
 MAINTAINER Manfred Touron "m@42.am"
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
`ubuntu:latest` does no longer ship `locale-gen` by default.